### PR TITLE
Wire DRAGEN.AllQC into DNAnexus app config choices

### DIFF
--- a/dx/GLnext/dxapp.json
+++ b/dx/GLnext/dxapp.json
@@ -21,7 +21,7 @@
       "name": "config",
       "class": "string",
       "default": "DeepVariant.WGS",
-      "choices": ["DeepVariant.WGS", "DeepVariant.WES", "DeepVariant.AllQC.WGS", "DeepVariant.AllQC.WES", "GLIMPSE", "GxS.AllQC", "DRAGEN"],
+      "choices": ["DeepVariant.WGS", "DeepVariant.WES", "DeepVariant.AllQC.WGS", "DeepVariant.AllQC.WES", "GLIMPSE", "GxS.AllQC", "DRAGEN", "DRAGEN.AllQC"],
       "help": "GLnext configuration preset"
     },
     {


### PR DESCRIPTION
### Motivation
- The `DRAGEN.AllQC` preset was added to the main app configs but was missing from the DNAnexus applet input choices, so the dx applet could not be selected to run that preset.

### Description
- Added `"DRAGEN.AllQC"` to the `config` input `choices` array in `dx/GLnext/dxapp.json` to expose the preset in the DNAnexus applet UI/API.

### Testing
- Ran `mvn antrun:run@ktlint` and `mvn antrun:run@ktlint-format`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cafe7b3d9c8333bd9d2fe20f827b82)